### PR TITLE
fix #7: add minimal circle ci config, should be placed in `.circleci/config.yml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ build:
 
 That's it! Happy hacking! 😊
 
+## Getting Started on CircleCi
+
+To set up CircleCi builds for your android project based on these images copy the [CircleCI recipe](/recipes/circle-ci/config.yml) into `.circleci/config.yml` of your project - happy building 🎉.
+
 ## Contributing
 
 Pull requests are welcome! 🎉

--- a/recipes/circle-ci/config.yml
+++ b/recipes/circle-ci/config.yml
@@ -1,0 +1,12 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: mreichelt/android:28
+    environment:
+      # from https://discuss.circleci.com/t/circle-ci-v2-and-android-memory-issues/11207
+      JVM_OPTS: "-Xmx1024m -XX:+PrintFlagsFinal -XX:+PrintGCDetails"
+      _JAVA_OPTIONS: "-Xmx1024m"
+    steps:
+      - checkout
+      - run: ./gradlew check -s --info


### PR DESCRIPTION
working sample over here: https://circleci.com/gh/rakutentech/android-manifest-config/6

I didn't look into your docker files in detail, but what are the advantage of using those over the e.g. the [circleci/android](https://hub.docker.com/r/circleci/android/) images (src [here](https://github.com/circleci/circleci-images/tree/staging/android) )?
I noticed that the circle provide images spin up way fast on circle ci, while the `mreichelt/android:28` one took 22 seconds to spin up... which is no surprise, they optimize for their own images 😂