### PR TITLE
Adding Jenkinsfile with delarative pipeline

### DIFF
--- a/recipes/jenkins-ci/Jenkinsfile
+++ b/recipes/jenkins-ci/Jenkinsfile
@@ -1,0 +1,14 @@
+pipeline {
+    agent {
+        docker {
+            image 'mreichelt/android:28'
+        }
+    }
+    stages {
+        stage('Build') {
+            steps {
+                sh './gradlew check assemble'
+            }
+        }
+    }
+}


### PR DESCRIPTION
Dear Marc,

I've made it up to the gradlew command in my dockerized Jenkins.
Unfortunately gradlew is not a part of Jenkins container so it's not found.

Could you please review the Jenkinsfile and let me know if I can improve anything there or test a build another way?

[Pipeline] stage
[Pipeline] { (Build)
[Pipeline] sh
[android] Running shell script
+ ./gradlew check assemble
/var/jenkins_home/workspace/android@tmp/durable-03a4064f/script.sh: 2: /var/jenkins_home/workspace/android@tmp/durable-03a4064f/script.sh: ./gradlew: not found