### PR TITLE
Build Tools 29.0.3 are available

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -7,4 +7,4 @@ RUN yes | sdkmanager \
       'build-tools;26.0.3' \
       'build-tools;27.0.3' \
       'build-tools;28.0.3' \
-      'build-tools;29.0.0' > /dev/null
+      'build-tools;29.0.3' > /dev/null


### PR DESCRIPTION
I'm not sure if it's easily possible to replace the images (should they be immutable once uploaded?), but the most recent version of the android build tools is 29.0.3, which gets downloaded each time when using the mreichelt/android:29-system image.