### PR TITLE
Update to Java 11, and create image for API 31

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -8,4 +8,5 @@ RUN yes | sdkmanager \
       'build-tools;27.0.3' \
       'build-tools;28.0.3' \
       'build-tools;29.0.2' \
-      'build-tools;30.0.2' > /dev/null
+      'build-tools;30.0.2' \
+      'build-tools;31.0.0' > /dev/null

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -3,9 +3,11 @@
 # abort on errors and on unset variables
 set -e -o nounset
 
-SDKS=$(echo {30..23})
-LATEST_SDKS=$(echo {30..28})
+SDKS=$(echo {31..31})
+LATEST_SDKS=$(echo {31..29})
 LATEST_PACKAGES=''; for SDK in $LATEST_SDKS; do LATEST_PACKAGES="platforms;android-${SDK} $LATEST_PACKAGES"; done
+PARALLEL=false
+DRY_RUN=false
 
 echo "SDKS = $SDKS"
 echo "LATEST_SDKS = $LATEST_SDKS"
@@ -13,38 +15,46 @@ echo "LATEST_PACKAGES = $LATEST_PACKAGES"
 
 docker login --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
 
+docker_push() {
+  if $DRY_RUN; then
+    echo "Dry run: docker push $1"
+  else
+    docker push $1
+  fi
+}
+
 build_deploy_minimal() {
     echo "Building 'minimal' image…"
     docker build --tag mreichelt/android:minimal --file minimal.Dockerfile .
-    docker push mreichelt/android:minimal
+    docker_push mreichelt/android:minimal
     echo
 }
 
 build_deploy_base() {
     echo "Building 'base' image…"
     docker build --tag mreichelt/android:base --file base.Dockerfile .
-    docker push mreichelt/android:base
+    docker_push mreichelt/android:base
     echo
 }
 
 build_deploy_base_ndk() {
     echo "Building 'base-ndk' image…"
     docker build --tag mreichelt/android:base-ndk --file base-ndk.Dockerfile .
-    docker push mreichelt/android:base-ndk
+    docker_push mreichelt/android:base-ndk
     echo
 }
 
 build_deploy_latest() {
     echo "Building 'latest' image…"
     docker build --tag mreichelt/android:latest --build-arg "latest_packages=${LATEST_PACKAGES}" --file latest.Dockerfile .
-    docker push mreichelt/android:latest
+    docker_push mreichelt/android:latest
     echo
 }
 
 build_deploy_latest_ndk() {
     echo "Building 'latest-ndk' image…"
     docker build --tag mreichelt/android:latest-ndk --file latest-ndk.Dockerfile .
-    docker push mreichelt/android:latest-ndk
+    docker_push mreichelt/android:latest-ndk
     echo
 }
 
@@ -54,13 +64,13 @@ build_deploy_sdk_and_system() {
     echo "Building '$sdk' image…"
     docker build --tag mreichelt/android:$sdk --build-arg android_sdk_version=$sdk --file sdk.Dockerfile .
     echo "Pushing '$sdk' image…"
-    docker push mreichelt/android:$sdk
+    docker_push mreichelt/android:$sdk
     echo
 
     echo "Building '$sdk-system' image…"
     docker build --tag mreichelt/android:$sdk-system --build-arg android_sdk_version=$sdk --file sdk-system.Dockerfile .
     echo "Pushing '$sdk-system' image…"
-    docker push mreichelt/android:$sdk-system
+    docker_push mreichelt/android:$sdk-system
     echo
 
     echo "Deleting images '$sdk' and '$sdk-system'"
@@ -73,13 +83,16 @@ build_deploy_latest
 build_deploy_base_ndk
 build_deploy_latest_ndk
 
-# remove some old images to save space on Travis CI
-docker rmi \
-    mreichelt/android:minimal \
-    mreichelt/android:latest \
-    mreichelt/android:base-ndk \
-    mreichelt/android:latest-ndk
-
 # build all sdk + system variants (in parallel because TravisCI has a 50m timeout)
-export -f build_deploy_sdk_and_system
-SHELL=$(type -p bash) parallel -j 2 --keep-order --line-buffer echo Building SDK {}\; build_deploy_sdk_and_system {} ::: $SDKS
+case $PARALLEL in
+  (true)
+    export -f build_deploy_sdk_and_system
+    SHELL=$(type -p bash) parallel -j 2 --keep-order --line-buffer echo Building SDK {}\; build_deploy_sdk_and_system {} ::: $SDKS
+    ;;
+  (false)
+    for SDK in $SDKS; do
+      echo Building SDK $SDK
+      build_deploy_sdk_and_system $SDK
+    done
+    ;;
+esac

--- a/minimal.Dockerfile
+++ b/minimal.Dockerfile
@@ -1,16 +1,15 @@
-FROM openjdk:8
+FROM openjdk:11
 LABEL maintainer="mcreichelt@gmail.com"
-
-ENV ANDROID_SDK_URL="https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip" \
+ENV ANDROID_SDK_URL="https://dl.google.com/android/repository/commandlinetools-linux-7583922_latest.zip" \
     ANT_HOME="/usr/share/ant" \
     MAVEN_HOME="/usr/share/maven" \
     GRADLE_HOME="/usr/share/gradle" \
     ANDROID_HOME="/opt/android" \
     ANDROID_NDK_HOME="/opt/android/ndk-bundle"
 
-ENV PATH $PATH:$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools:$ANDROID_HOME/build-tools/$ANDROID_BUILD_TOOLS_VERSION:$ANT_HOME/bin:$MAVEN_HOME/bin:$GRADLE_HOME/bin:${ANDROID_NDK_HOME}
+ENV PATH $PATH:$ANDROID_HOME/cmdline-tools/tools/bin:$ANT_HOME/bin:$MAVEN_HOME/bin:$GRADLE_HOME/bin:${ANDROID_NDK_HOME}
 
-WORKDIR /opt
+WORKDIR /tmp
 
 # Install some dependencies
 RUN dpkg --add-architecture i386 && \
@@ -18,14 +17,15 @@ RUN dpkg --add-architecture i386 && \
     apt-get install -qq -y wget curl maven ant git gradle libncurses5:i386 libstdc++6:i386 zlib1g:i386 file libpulse0 qt5-default > /dev/null 2>&1
 
 # Download emulator script
-RUN wget --quiet --output-document=android-wait-for-emulator https://raw.githubusercontent.com/travis-ci/travis-cookbooks/0f497eb71291b52a703143c5cd63a217c8766dc9/community-cookbooks/android-sdk/files/default/android-wait-for-emulator && \
-    chmod +x android-wait-for-emulator
+RUN wget --quiet --output-document=/opt/android-wait-for-emulator https://raw.githubusercontent.com/travis-ci/travis-cookbooks/0f497eb71291b52a703143c5cd63a217c8766dc9/community-cookbooks/android-sdk/files/default/android-wait-for-emulator && \
+    chmod +x /opt/android-wait-for-emulator
 
-# Install Android SDK tools
-RUN mkdir android && cd android && \
+# Install Android commandline tools
+RUN mkdir --parents /opt/android/cmdline-tools && \
     wget --quiet --output-document=tools.zip ${ANDROID_SDK_URL} && \
     unzip -qq tools.zip && \
-    rm tools.zip
+    mv cmdline-tools /opt/android/cmdline-tools/tools && \
+    rm -Rf /tmp/*
 
 RUN yes | sdkmanager 'tools' 'platform-tools' > /dev/null
 

--- a/sdk-system.Dockerfile
+++ b/sdk-system.Dockerfile
@@ -6,4 +6,4 @@ ARG android_sdk_version
 # get more from `sdkmanager --list` (add '--verbose' to read long package names)
 RUN yes | sdkmanager \
     'emulator' \
-    "system-images;android-${android_sdk_version};google_apis;x86" > /dev/null
+    "system-images;android-${android_sdk_version};google_apis;x86_64" > /dev/null


### PR DESCRIPTION
- fix #24 
- fix #25
- also: add option to dry run (create Docker images, but do not deploy)
- also: add option to disable parallel run